### PR TITLE
Compatibility fix for horizontal rule

### DIFF
--- a/noted
+++ b/noted
@@ -27,7 +27,7 @@ create() {
     result="${TEMPLATE_TEXT}"
     result="${result/HEADERTEXT/$headerText}"
     result="${result/TIMESTAMP/$timestamp}"
-    echo -e "$result\n\n"
+    echo -e "\n$result\n"
   }
   TEMPLATE_TEXT=""
   if [ -f "${NOTED_TEMPLATE_FILE}" ]; then
@@ -42,7 +42,6 @@ TIMESTAMP
 
 
 ---
-
 EOF
   fi
   mkdir -p "${NOTED_MARKDOWN_HOME}"


### PR DESCRIPTION
I use [code-server](https://github.com/cdr/code-server) installed in a headless VM to test noted and I have an issue when creating a new md file. I don't see in the md preview, the first entry. 

After a little bit of digging online, I found a [Markdown guide](https://www.markdownguide.org/basic-syntax/) which states that for compatibility it is better to add a new line before and after a horizontal rule. Adding a new line at the beginning of the file fixed this. 

On GitHub the first entry is displayed correctly with existing version of the script.