### PR TITLE
Fix misplaced option & ordered list numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cd $HOME/Documents
 3. Clone this repository to your Documents folder.
 
 ```shell
-git clone git@github.com:scottashipp/noted.git -C $HOME/Documents
+git -C $HOME/Documents clone git@github.com:scottashipp/noted.git
 ```
 
 4. Symlink the file:
@@ -62,7 +62,7 @@ git clone git@github.com:scottashipp/noted.git -C $HOME/Documents
 ln -s $HOME/Documents/noted/noted /usr/local/bin/noted
 ```
 
-6. Verify that it is visible on the path:
+5. Verify that it is visible on the path:
 
 ```shell
 noted version


### PR DESCRIPTION
Hi back :)

Following #5, I changed the clone command to use the option w/ the right syntax and it's fine. ( I kept the -C option because without it it tries to clone the repo as $HOME/Documents, but it exists already..)

Have a great evening !
