### PR TITLE
Add todo feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,35 +44,29 @@ Getting started with _Noted_ only requires that `noted` is placed on your path.
 A good standard way to do this is to symlink the `noted` script to `/usr/local/bin` as follows.
 
 1. Open a terminal.
-2. Change to your `Documents` directory.
-
-```shell
-cd $HOME/Documents
-```
-
-3. Clone this repository to your Documents folder.
+2. Clone this repository to your Documents folder.
 
 ```shell
 git -C $HOME/Documents clone git@github.com:scottashipp/noted.git
 ```
 
-4. Symlink the file:
+3. Symlink the file:
 
 ```shell
 ln -s $HOME/Documents/noted/noted /usr/local/bin/noted
 ```
 
-5. Verify that it is visible on the path:
+4. Verify that it is visible on the path:
 
 ```shell
 noted version
 ```
 
-If the above outputs `noted v0.0.1` then all is well. Check out the [Typical usage](#typical-usage) section below to take your first notes!
+If the above outputs `noted v0.0.3` then all is well. Check out the [Typical usage](#typical-usage) section below to take your first notes!
 
 ### Optional steps
 
-You may want to follow the [configuration guide](#configuration-guide) if you do not like the defaults.
+You may want to follow the [configuration guide](#configuration-guide) if you do not like [the defaults](#default-values).
 
 ## Typical usage
 
@@ -133,8 +127,18 @@ You now have a source-controlled, time-seried journal of events. Most importantl
 
 ## Subcommand reference
 
-_Noted_ works like many other CLI's, through the use of subcommands. It currently supports config, create, edit, version, and view. These are fully-specified in
-the [subcommand reference](subcommands.md)
+_Noted_ works like many other CLI's, through the use of subcommands. Subcommands are fully-specified in the [subcommand reference](subcommands.md).
+
+> NOTE: You can find detailed information about each subcommand in the [subcommand reference](subcommands.md). Skip to a specific subcommand using the list below. 
+
+Noted currently supports the following commands:
+
+- [config](subcommands.md#config)
+- [create](subcommands.md#create)
+- [edit/view](subcommands.md#edit--view)
+- [todos](subcommands.md#todos)
+- [version](subcommands.md#version)
+- [view](subcommands.md#edit--view)
 
 ## Configuration guide
 
@@ -148,6 +152,7 @@ The following default values are configured.
 | NOTED_FILE_NAME_DATE_FORMAT | The date format string used as the file name for new notes. | `"+%Y-%m-%d"` | 
 | NOTED_TIMESTAMP_FORMAT | The timestamp format for the timestamp placed on new entries. | `"+%H:%M:%S UTC"` |
 | NOTED_TEMPLATE_FILE | A file containing a Markdown-formatted entry template to use. | `""` <br /> (It is empty by default. Which means the script's own default template will be used.) |
+| NOTED_TODO_MARKER | A string that indicates the following text is a TODO item. This text is searched for by the `todos` command. | `TODO` |
 
 ### Configuring custom values
 
@@ -164,6 +169,7 @@ NOTED_FILE_NAME_DATE_FORMAT="+%m-%d-%Y"
 NOTED_TIMESTAMP_FORMAT="+%H:%M:%S Pacific"
 # Use my own template file
 NOTED_TEMPLATE_FILE=$HOME/Documents/mynotes/template.md
+NOTED_TODO_MARKER="REMINDER:"
 ```
 
 Both the `NOTED_FILE_NAME_DATE_FORMAT` and the `NOTED_TIMESTAMP_FORMAT` are format strings as specified by the `date` shell command. You can learn more about

--- a/noted
+++ b/noted
@@ -84,6 +84,7 @@ outputConfig() {
   echo "NOTED_FILE_NAME_DATE_FORMAT=${NOTED_FILE_NAME_DATE_FORMAT}"
   echo "NOTED_TIMESTAMP_FORMAT=${NOTED_TIMESTAMP_FORMAT}"
   echo "NOTED_TEMPLATE_FILE=${NOTED_TEMPLATE_FILE:-<<DEFAULT>>}"
+  echo "NOTED_TODO_MARKER=${NOTED_TODO_MARKER}"
 }
 
 validate() {
@@ -105,7 +106,7 @@ view() {
 # END FUNCTIONS
 #
 
-VERSION="0.0.2"
+VERSION="0.0.3"
 
 #
 # Default Settings
@@ -122,6 +123,7 @@ NOTED_TIMESTAMP_FORMAT="+%H:%M:%S UTC"
 NOTED_TEMPLATE_FILE=""
 # keep the directory where notes are stored here
 NOTED_MARKDOWN_HOME=$HOME/Documents/notes
+NOTED_TODO_MARKER="TODO"
 
 #
 # Override with any additional settings
@@ -148,6 +150,10 @@ elif [[ "${subcommand}" == "edit" ]] || [[ "${subcommand}" == "view" ]]; then
 elif [[ "${subcommand}" == "grep" ]]; then
   shift
   ngrep "$@"
+elif [[ "${subcommand}" == 'todos' ]]; then
+  fgrep -rH "${NOTED_TODO_MARKER}" "${NOTED_MARKDOWN_HOME}" | fgrep -v ~~
+  if [ 1 == $? ]; then echo "Congratulations! No TODOs found!"; fi
+  echo
 else
   # create / default
   OPTIONAL_FILE=""

--- a/subcommands.md
+++ b/subcommands.md
@@ -27,11 +27,16 @@ All uses of `noted` require a subcommand. If one is not supplied, the default `c
   - [Overview](#overview-3)
   - [Arguments & Flags](#arguments--flags-3)
   - [Examples](#examples-3)
-- [version](#version)
+- [todos](#todos)
   - [Synopsis](#synopsis-4)
   - [Overview](#overview-4)
   - [Arguments & Flags](#arguments--flags-4)
   - [Examples](#examples-4)
+- [version](#version)
+  - [Synopsis](#synopsis-5)
+  - [Overview](#overview-5)
+  - [Arguments & Flags](#arguments--flags-5)
+  - [Examples](#examples-5)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -200,6 +205,36 @@ Perform a search for "Jenkins" and show line numbers:
 
 ```shell
 noted grep Jenkins -n
+```
+
+## todos
+
+Lists any todos that you have previously saved in your notes.
+
+### Synopsis
+
+```shell
+noted todos 
+```
+
+### Overview
+
+Runs a recursive grep in your configured notes directory for the value configured in `NOTED_TODO_MARKER`, excluding
+results that contain strikethrough text (markdown value of `~~`) as a means of detecting "crossed-out" todo items.
+
+> REMINDER:
+> `NOTED_TODO_MARKER` is configured to `TODO` by default but can be overridden in the `$HOME/.notedconfig` file. See the [configuration guide](README.md#configuration-guide) for more.
+
+### Arguments & Flags
+
+N/A
+
+### Examples
+
+View any TODO items that are not crossed-out:
+
+```shell
+noted todos
 ```
 
 ## version


### PR DESCRIPTION
- Typing noted todos now greps for special marker text defined in configuration
  so that you can see a list of things you wrote down as to do's.

- NOTED_TODO_MARKER variable added to configuration to make this marker text
  customizable by the user.

- Updated README with TODO feature information.

- Some further edits to the README for readability and usability.